### PR TITLE
More configuration around channel creation

### DIFF
--- a/lightning/api_grpc_test.go
+++ b/lightning/api_grpc_test.go
@@ -659,3 +659,10 @@ func TestGetChannelCloseInfoGrpc(t *testing.T) {
 	assert.Equal(t, Unknown, resp[1].Closer)
 	assert.Equal(t, uint64(0), resp[1].ChanID)
 }
+
+func TestGetMsatsFromInvoice(t *testing.T) {
+	expected := uint64(100000 * 1000)
+	assert.Equal(t, expected, GetMsatsFromInvoice("lntb1m1pjyxysnpp5x24d0yvj0c7atwhf88l8c7xu7l80xnymhhuaz7j5u4yp6dfcgqcqdqqcqzpgxqyz5vqsp5uq3c68sh2fqrdwl2l90ccxw7qpfn65cgs3n5lrd8nwu3f2hrxk8q9qyyssqzdr5gqj35u30fra74d02utsq3gljkhfj9zpvxp8ljhaclz49zkjpy2gxha53ejyu8am8m0q97ql7algt068tze8p8wwfquc4e7m3z8cp6a2mp9"))
+	assert.Equal(t, expected, GetMsatsFromInvoice("lnbc1m1pjyxyw7pp5ftl92yhqxnp925ppl7tr7txze2px38ccgr5msekvgru0v9fthzcqdqqcqzpgxqyz5vqsp5xa4zr56xw6fkprpc9w75cyyv4zdv0hxw7em770qetxsuz9ywsy6s9qyyssqpuyv9ft83utw87wv0xlan4r4wju7rd4ktk6cyls9da6w0qjjagn94x5hjlaez0l5tfw9ttkhezh2jw9hgd0vpncfyrpspzatww57pvsq4cx0cg"))
+	assert.Equal(t, uint64(0), GetMsatsFromInvoice("lnbc"))
+}

--- a/plugins/boltz/common/swaplimits.go
+++ b/plugins/boltz/common/swaplimits.go
@@ -4,13 +4,14 @@
 package common
 
 type SwapLimits struct {
-	MaxFeePercentage float64
-	AllowZeroConf    bool
-	MinSwap          uint64
-	MaxSwap          uint64
-	DefaultSwap      uint64
-	MaxAttempts      int
-	BackOffAmount    float64
+	MaxFeePercentage        float64
+	AllowZeroConf           bool
+	MinSwap                 uint64
+	MaxSwap                 uint64
+	DefaultSwap             uint64
+	MaxAttempts             int
+	BackOffAmount           float64
+	BelowMinAmountIsSuccess bool
 }
 
 type JobID int64

--- a/plugins/boltz/data/plugindata.go
+++ b/plugins/boltz/data/plugindata.go
@@ -20,15 +20,17 @@ type GetSleepTimeFn func(in common.FsmIn) time.Duration
 type DeleteJobFn func(jobID int64) error
 
 type PluginData struct {
-	ReferralCode    string
-	ChainParams     *chaincfg.Params
-	Filter          filter.FilteringInterface
-	CryptoAPI       *crypto.CryptoAPI
-	Redeemer        *redeemer.Redeemer[common.FsmIn]
-	ReverseRedeemer *redeemer.Redeemer[common.FsmIn]
-	Limits          common.SwapLimits
-	BoltzAPI        *bapi.BoltzPrivateAPI
-	ChangeStateFn   ChangeStateFn
-	GetSleepTimeFn  GetSleepTimeFn
-	DeleteJobFn     DeleteJobFn
+	ReferralCode        string
+	ChainParams         *chaincfg.Params
+	Filter              filter.FilteringInterface
+	CryptoAPI           *crypto.CryptoAPI
+	Redeemer            *redeemer.Redeemer[common.FsmIn]
+	ReverseRedeemer     *redeemer.Redeemer[common.FsmIn]
+	Limits              common.SwapLimits
+	BoltzAPI            *bapi.BoltzPrivateAPI
+	ChangeStateFn       ChangeStateFn
+	GetSleepTimeFn      GetSleepTimeFn
+	DeleteJobFn         DeleteJobFn
+	AllowChanCreation   bool
+	PrivateChanCreation bool
 }

--- a/plugins/boltz/swapmachine/swapmachine_test.go
+++ b/plugins/boltz/swapmachine/swapmachine_test.go
@@ -52,6 +52,8 @@ func NewFakeSwapMachine(pd data.PluginData, nodeDataInvalidator entities.Invalid
 	s.NodeDataInvalidator = nodeDataInvalidator
 	s.JobDataToSwapData = jobDataToSwapData
 	s.LnAPI = lnAPI
+	s.AllowChanCreation = true
+	s.PrivateChanCreation = false
 
 	s.Machine.States[common.SwapFailed] = func(in common.FsmIn) common.FsmOut {
 		s.CurrentState = common.SwapFailed


### PR DESCRIPTION
Wanted to include this already in PR yesterday but didn't finish that fast.

This brings:
- proper parsing of amount from invoice
- configuration option for allowing channel opening from boltz (defaulting to true)
- BelowMinAmountIsSuccess to limit that if we would need to swap something very low to treat this as success (instead of still swapping the min amount)
- reporting that funds were successfully claimed